### PR TITLE
Add `coauthor remove` command

### DIFF
--- a/src/coauthors_file.rs
+++ b/src/coauthors_file.rs
@@ -14,7 +14,7 @@ fn coauthors_file() -> String {
     let file_path = Path::new(&file_path_string);
 
     if !Path::new(&file_path).exists() {
-       fs::File::create(file_path);
+       let _ = fs::File::create(file_path);
     }
 
     return file_path_string;
@@ -23,13 +23,18 @@ fn coauthors_file() -> String {
 pub fn store_coauthor(coauthor: Coauthor) {
     let mut coauthors = read_coauthors();
     coauthors.push(coauthor);
-    let coauthor_list = CoauthorsStorage {
-        coauthors: coauthors,
-    };
 
-    let toml = toml::to_string(&coauthor_list).unwrap();
+    write_coauthors(coauthors);
+}
 
-    fs::write(coauthors_file(), &toml).expect("Unable to write file");
+pub fn remove_coauthor_by_username(username: String) {
+    let filtered_coauthors = read_coauthors()
+        .iter()
+        .filter(|coauthor| coauthor.username != username)
+        .cloned()
+        .collect();
+
+    write_coauthors(filtered_coauthors);
 }
 
 pub fn read_coauthors() -> Vec<Coauthor> {
@@ -42,4 +47,14 @@ pub fn read_coauthors() -> Vec<Coauthor> {
     let coauthors_storage: CoauthorsStorage = toml::from_str(&file_contents).unwrap();
 
     return coauthors_storage.coauthors;
+}
+
+fn write_coauthors(coauthors: Vec<Coauthor>) {
+    let coauthor_list = CoauthorsStorage {
+        coauthors: coauthors,
+    };
+
+    let toml = toml::to_string(&coauthor_list).unwrap();
+
+    fs::write(coauthors_file(), &toml).expect("Unable to write file");
 }

--- a/src/input_command.rs
+++ b/src/input_command.rs
@@ -2,16 +2,26 @@
 pub enum InputCommand {
     Add,
     List,
+    Remove(String),
     Help,
     Unknown(String),
 }
 
-pub fn parse_command(arguments: Vec<String>) -> InputCommand {
+pub fn parse_command(arguments: Vec<String>) -> Result<InputCommand, &'static str> {
     match arguments[1].as_ref() {
-        "a" | "add" => InputCommand::Add,
-        "l" | "list" => InputCommand::List,
-        "h" | "help" => InputCommand::Help,
-        anything => InputCommand::Unknown(anything.to_string()),
+        "a" | "add" => Ok(InputCommand::Add),
+
+        "l" | "list" => Ok(InputCommand::List),
+
+        "r" | "remove" => {
+            if arguments.len() < 3 { return Err("No username defined"); }
+
+            return Ok(InputCommand::Remove(arguments[2].to_string()));
+        },
+
+        "h" | "help" => Ok(InputCommand::Help),
+
+        anything => Ok(InputCommand::Unknown(anything.to_string())),
     }
 }
 
@@ -27,11 +37,30 @@ mod tests {
     fn test_add_command_parsing() {
         assert_eq!(
             parse_command(vec_of_strings!["bin/coauthor", "a"]),
-            InputCommand::Add
+            Ok(InputCommand::Add)
         );
         assert_eq!(
             parse_command(vec_of_strings!["bin/coauthor", "add"]),
-            InputCommand::Add
+            Ok(InputCommand::Add)
+        );
+    }
+
+
+    #[test]
+    fn test_remove_command_parsing() {
+        assert_eq!(
+            parse_command(vec_of_strings!["bin/coauthor", "r", "username"]),
+            Ok(InputCommand::Remove(String::from("username")))
+        );
+        assert_eq!(
+            parse_command(vec_of_strings!["bin/coauthor", "remove", "username"]),
+            Ok(InputCommand::Remove(String::from("username")))
+        );
+
+        // When third argument is missing
+        assert_eq!(
+            parse_command(vec_of_strings!["bin/coauthor", "remove"]),
+            Err("No username defined")
         );
     }
 
@@ -39,11 +68,11 @@ mod tests {
     fn test_list_command_parsing() {
         assert_eq!(
             parse_command(vec_of_strings!["bin/coauthor", "l"]),
-            InputCommand::List
+            Ok(InputCommand::List)
         );
         assert_eq!(
             parse_command(vec_of_strings!["bin/coauthor", "list"]),
-            InputCommand::List
+            Ok(InputCommand::List)
         );
     }
 
@@ -51,11 +80,11 @@ mod tests {
     fn test_help_command_parsing() {
         assert_eq!(
             parse_command(vec_of_strings!["bin/coauthor", "h"]),
-            InputCommand::Help
+            Ok(InputCommand::Help)
         );
         assert_eq!(
             parse_command(vec_of_strings!["bin/coauthor", "help"]),
-            InputCommand::Help
+            Ok(InputCommand::Help)
         );
     }
 
@@ -63,7 +92,7 @@ mod tests {
     fn test_unkown_command_parsing() {
         assert_eq!(
             parse_command(vec_of_strings!["bin/coauthor", "anything"]),
-            InputCommand::Unknown(String::from("anything"))
+            Ok(InputCommand::Unknown(String::from("anything")))
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,24 +5,38 @@ mod input_command;
 
 use std::env;
 use coauthor::Coauthor;
+use input_command::InputCommand;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let command = input_command::parse_command(args);
 
+    match input_command::parse_command(args) {
+        Ok(command) => run_command(command),
+        Err(error) => eprintln!("{}", error),
+    }
+}
+
+fn run_command(command: InputCommand) {
     match command {
-        input_command::InputCommand::Add => {
+        InputCommand::Add => {
             let coauthor = cli_input::request_new_coauthor();
             coauthors_file::store_coauthor(coauthor.clone());
         }
-        input_command::InputCommand::List => {
+
+        InputCommand::List => {
             let coauthors = coauthors_file::read_coauthors();
             for coauthor in coauthors {
                 print_coauthor(coauthor);
             }
         },
-        input_command::InputCommand::Help => print_help_section(),
-        input_command::InputCommand::Unknown(action) => {
+
+        InputCommand::Remove(username) => {
+            coauthors_file::remove_coauthor_by_username(username);
+        }
+
+        InputCommand::Help => print_help_section(),
+
+        InputCommand::Unknown(action) => {
             print_unkown_command(action);
             print_help_section();
         }
@@ -43,10 +57,11 @@ fn print_help_section() {
     Store coauthors and update them easily in your commit template.
 
     USAGE:
-      add             Starts a prompt to add an coauthor.
-      list            Lists all stored coauthors.
+      add                   Starts a prompt to add an coauthor.
+      list                  Lists all stored coauthors.
+      remove [username]     Removes a coauthor from the local machine.
 
-      help            Show this help section.
+      help                  Show this help section.
     "#
     );
 }


### PR DESCRIPTION
This will allow for removing stored coauthors by username

Changes:
- Add `remove` command
- Refactor `input_command::parse_command` to return a `Result`