### PR TITLE
Adds the `set` command for setting coauthors

### DIFF
--- a/src/coauthor.rs
+++ b/src/coauthor.rs
@@ -6,3 +6,29 @@ pub struct Coauthor {
     pub name: String,
     pub email: String,
 }
+
+trait GitMessageSerializable {
+    fn to_coauthored_string(coauthor: Coauthor) -> String;
+}
+
+impl GitMessageSerializable for Coauthor {
+    fn to_coauthored_string(coauthor: Coauthor) -> String {
+       return format!("Co-Authored-By: {} <{}>", coauthor.name, coauthor.email);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_coauthored_string_test() {
+        let coauthor = Coauthor {
+            username: "johantell".to_string(),
+            name: "Johan Tell".to_string(),
+            email: "johan.tell@example.com".to_string()
+        };
+
+        assert_eq!(Coauthor::to_coauthored_string(coauthor), "Co-Authored-By: Johan Tell <johan.tell@example.com>");
+    }
+}

--- a/src/coauthor.rs
+++ b/src/coauthor.rs
@@ -6,29 +6,3 @@ pub struct Coauthor {
     pub name: String,
     pub email: String,
 }
-
-trait GitMessageSerializable {
-    fn to_coauthored_string(coauthor: Coauthor) -> String;
-}
-
-impl GitMessageSerializable for Coauthor {
-    fn to_coauthored_string(coauthor: Coauthor) -> String {
-       return format!("Co-Authored-By: {} <{}>", coauthor.name, coauthor.email);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn to_coauthored_string_test() {
-        let coauthor = Coauthor {
-            username: "johantell".to_string(),
-            name: "Johan Tell".to_string(),
-            email: "johan.tell@example.com".to_string()
-        };
-
-        assert_eq!(Coauthor::to_coauthored_string(coauthor), "Co-Authored-By: Johan Tell <johan.tell@example.com>");
-    }
-}

--- a/src/coauthors_file.rs
+++ b/src/coauthors_file.rs
@@ -14,7 +14,7 @@ fn coauthors_file() -> String {
     let file_path = Path::new(&file_path_string);
 
     if !Path::new(&file_path).exists() {
-       let _ = fs::File::create(file_path);
+        let _ = fs::File::create(file_path);
     }
 
     return file_path_string;
@@ -40,22 +40,22 @@ pub fn remove_coauthor_by_username(username: String) {
 pub fn get_coauthors(coauthors: Vec<String>) -> Result<Vec<Coauthor>, Vec<String>> {
     let coauthors_structs = read_coauthors();
 
-    let result: (Vec<Coauthor>, Vec<String>) = coauthors.iter()
-        .fold(
-            (vec![], vec![]),
-            |(mut matching_coauthors, mut missing_coauthors), username| {
-                let matching_coauthor = coauthors_structs.iter()
-                    .find(|coauthor| coauthor.username == username.to_string())
-                    .cloned();
+    let result: (Vec<Coauthor>, Vec<String>) = coauthors.iter().fold(
+        (vec![], vec![]),
+        |(mut matching_coauthors, mut missing_coauthors), username| {
+            let matching_coauthor = coauthors_structs
+                .iter()
+                .find(|coauthor| coauthor.username == username.to_string())
+                .cloned();
 
-                match matching_coauthor {
-                    Some(coauthor) => matching_coauthors.push(coauthor),
-                    None => missing_coauthors.push(username.to_string())
-                }
-
-                return (matching_coauthors, missing_coauthors);
+            match matching_coauthor {
+                Some(coauthor) => matching_coauthors.push(coauthor),
+                None => missing_coauthors.push(username.to_string()),
             }
-        );
+
+            return (matching_coauthors, missing_coauthors);
+        },
+    );
 
     let (found_coauthors, missing_coauthors) = result;
 

--- a/src/coauthors_file.rs
+++ b/src/coauthors_file.rs
@@ -37,6 +37,35 @@ pub fn remove_coauthor_by_username(username: String) {
     write_coauthors(filtered_coauthors);
 }
 
+pub fn get_coauthors(coauthors: Vec<String>) -> Result<Vec<Coauthor>, Vec<String>> {
+    let coauthors_structs = read_coauthors();
+
+    let result: (Vec<Coauthor>, Vec<String>) = coauthors.iter()
+        .fold(
+            (vec![], vec![]),
+            |(mut matching_coauthors, mut missing_coauthors), username| {
+                let matching_coauthor = coauthors_structs.iter()
+                    .find(|coauthor| coauthor.username == username.to_string())
+                    .cloned();
+
+                match matching_coauthor {
+                    Some(coauthor) => matching_coauthors.push(coauthor),
+                    None => missing_coauthors.push(username.to_string())
+                }
+
+                return (matching_coauthors, missing_coauthors);
+            }
+        );
+
+    let (found_coauthors, missing_coauthors) = result;
+
+    if missing_coauthors.len() == 0 {
+        return Ok(found_coauthors);
+    } else {
+        return Err(missing_coauthors);
+    }
+}
+
 pub fn read_coauthors() -> Vec<Coauthor> {
     let file_contents = fs::read_to_string(coauthors_file()).expect("Unable to read file");
 

--- a/src/git_commit_template_file.rs
+++ b/src/git_commit_template_file.rs
@@ -28,6 +28,10 @@ fn template_file() -> String {
         let file_path_string = tilde("~/.config/git/.gitmessage").to_string();
         let file_path = Path::new(&file_path_string);
         let _ = fs::File::create(file_path);
+        let _ = Command::new("git")
+            .args(&["config", "set", "commit.template", &file_path_string])
+            .output()
+            .expect("Failed to configure the git template file");
         println!("commit template missing. Added it to {}", file_path_string);
 
         return file_path_string;

--- a/src/git_commit_template_file.rs
+++ b/src/git_commit_template_file.rs
@@ -1,0 +1,71 @@
+use crate::coauthor::Coauthor;
+use shellexpand::tilde;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+pub fn set_current_coauthors(coauthors: Vec<Coauthor>) {
+    let coauthor_strings: Vec<String> = coauthors
+        .iter()
+        .map(|coauthor| to_coauthored_string(coauthor))
+        .collect();
+
+    let template_string = coauthor_template_string(coauthor_strings);
+
+    fs::write(template_file(), &template_string).expect("Unable to write file");
+}
+
+fn template_file() -> String {
+    let output = Command::new("git")
+        .args(&["config", "commit.template"])
+        .output()
+        .expect("Failed to retrieve the configured git template");
+
+    let mut path = String::from_utf8_lossy(&output.stdout).to_string();
+    path.pop(); // Removes trailing `\n`
+
+    if path == "" {
+        let file_path_string = tilde("~/.config/git/.gitmessage").to_string();
+        let file_path = Path::new(&file_path_string);
+        let _ = fs::File::create(file_path);
+        println!("commit template missing. Added it to {}", file_path_string);
+
+        return file_path_string;
+    }
+
+    return path;
+}
+
+fn coauthor_template_string(coauthor_strings: Vec<String>) -> String {
+    return [
+        "", // The convention is that there should be two empty lines
+        "", // in a row before the coauthors are defined
+        "# Coauthors managed by coauthor:",
+        &coauthor_strings.join("\n"),
+        "# coauthor end",
+    ]
+    .join("\n");
+}
+
+fn to_coauthored_string(coauthor: &Coauthor) -> String {
+    return format!("Co-Authored-By: {} <{}>", coauthor.name, coauthor.email);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_coauthored_string_test() {
+        let coauthor = Coauthor {
+            username: "johantell".to_string(),
+            name: "Johan Tell".to_string(),
+            email: "johan.tell@example.com".to_string(),
+        };
+
+        assert_eq!(
+            to_coauthored_string(&coauthor),
+            "Co-Authored-By: Johan Tell <johan.tell@example.com>"
+        );
+    }
+}

--- a/src/input_command.rs
+++ b/src/input_command.rs
@@ -15,13 +15,17 @@ pub fn parse_command(arguments: Vec<String>) -> Result<InputCommand, &'static st
         "l" | "list" => Ok(InputCommand::List),
 
         "r" | "remove" => {
-            if arguments.len() < 3 { return Err("No username defined"); }
+            if arguments.len() < 3 {
+                return Err("No username defined");
+            }
 
             return Ok(InputCommand::Remove(arguments[2].to_string()));
-        },
+        }
 
         "s" | "set" => {
-            if arguments.len() < 3 { return Err("No coauthor(s) defined"); }
+            if arguments.len() < 3 {
+                return Err("No coauthor(s) defined");
+            }
 
             return Ok(InputCommand::Set(arguments[2..].to_vec()));
         }
@@ -51,7 +55,6 @@ mod tests {
             Ok(InputCommand::Add)
         );
     }
-
 
     #[test]
     fn test_remove_command_parsing() {
@@ -83,7 +86,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_set_command_parsing() {
         assert_eq!(
@@ -97,10 +99,14 @@ mod tests {
 
         // With multiple coauthors
         assert_eq!(
-            parse_command(vec_of_strings!["bin/coauthor", "set", "username1", "username2"]),
+            parse_command(vec_of_strings![
+                "bin/coauthor",
+                "set",
+                "username1",
+                "username2"
+            ]),
             Ok(InputCommand::Set(vec_of_strings!["username1", "username2"]))
         );
-
 
         // When third argument is missing
         assert_eq!(

--- a/src/input_command.rs
+++ b/src/input_command.rs
@@ -3,6 +3,7 @@ pub enum InputCommand {
     Add,
     List,
     Remove(String),
+    Set(Vec<String>),
     Help,
     Unknown(String),
 }
@@ -18,6 +19,12 @@ pub fn parse_command(arguments: Vec<String>) -> Result<InputCommand, &'static st
 
             return Ok(InputCommand::Remove(arguments[2].to_string()));
         },
+
+        "s" | "set" => {
+            if arguments.len() < 3 { return Err("No coauthor(s) defined"); }
+
+            return Ok(InputCommand::Set(arguments[2..].to_vec()));
+        }
 
         "h" | "help" => Ok(InputCommand::Help),
 
@@ -73,6 +80,32 @@ mod tests {
         assert_eq!(
             parse_command(vec_of_strings!["bin/coauthor", "list"]),
             Ok(InputCommand::List)
+        );
+    }
+
+
+    #[test]
+    fn test_set_command_parsing() {
+        assert_eq!(
+            parse_command(vec_of_strings!["bin/coauthor", "s", "username"]),
+            Ok(InputCommand::Set(vec_of_strings!["username"]))
+        );
+        assert_eq!(
+            parse_command(vec_of_strings!["bin/coauthor", "set", "username"]),
+            Ok(InputCommand::Set(vec_of_strings!["username"]))
+        );
+
+        // With multiple coauthors
+        assert_eq!(
+            parse_command(vec_of_strings!["bin/coauthor", "set", "username1", "username2"]),
+            Ok(InputCommand::Set(vec_of_strings!["username1", "username2"]))
+        );
+
+
+        // When third argument is missing
+        assert_eq!(
+            parse_command(vec_of_strings!["bin/coauthor", "set"]),
+            Err("No coauthor(s) defined")
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,11 +74,13 @@ fn print_help_section() {
     Store coauthors and update them easily in your commit template.
 
     USAGE:
-      add                   Starts a prompt to add an coauthor.
-      list                  Lists all stored coauthors.
-      remove [username]     Removes a coauthor from the local machine.
+      add                               Starts a prompt to add an coauthor.
+      list                              Lists all stored coauthors.
+      remove [username]                 Removes a coauthor from the local machine.
 
-      help                  Show this help section.
+      set [username [username ..]]      Updates the git template with predefined coauthors.
+
+      help                              Show this help section.
     "#
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,10 @@ fn run_command(command: InputCommand) {
             coauthors_file::remove_coauthor_by_username(username);
         }
 
+        InputCommand::Set(usernames) => {
+            println!("{:#?}", usernames);
+        }
+
         InputCommand::Help => print_help_section(),
 
         InputCommand::Unknown(action) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 mod cli_input;
 mod coauthor;
 mod coauthors_file;
+mod git_commit_template_file;
 mod input_command;
 
-use std::env;
 use coauthor::Coauthor;
 use input_command::InputCommand;
+use std::env;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -28,26 +29,24 @@ fn run_command(command: InputCommand) {
             for coauthor in coauthors {
                 print_coauthor(coauthor);
             }
-        },
+        }
 
         InputCommand::Remove(username) => {
             coauthors_file::remove_coauthor_by_username(username);
         }
 
-        InputCommand::Set(usernames) => {
-            match coauthors_file::get_coauthors(usernames) {
-                Ok(coauthors) => {
-                    println!("setting {:#?}", coauthors);
-                },
+        InputCommand::Set(usernames) => match coauthors_file::get_coauthors(usernames) {
+            Ok(coauthors) => {
+                git_commit_template_file::set_current_coauthors(coauthors);
+            }
 
-                Err(non_existing_usernames) => {
-                    println!(
+            Err(non_existing_usernames) => {
+                println!(
                         "{} could not be found in the storage. run `coauthor list` to see which one are available",
                         non_existing_usernames.join(", ")
                     );
-                }
             }
-        }
+        },
 
         InputCommand::Help => print_help_section(),
 
@@ -59,7 +58,10 @@ fn run_command(command: InputCommand) {
 }
 
 fn print_coauthor(coauthor: Coauthor) {
-    println!("[{}] {} <{}>", coauthor.username, coauthor.name, coauthor.email);
+    println!(
+        "[{}] {} <{}>",
+        coauthor.username, coauthor.name, coauthor.email
+    );
 }
 
 fn print_unkown_command(command: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,18 @@ fn run_command(command: InputCommand) {
         }
 
         InputCommand::Set(usernames) => {
-            println!("{:#?}", usernames);
+            match coauthors_file::get_coauthors(usernames) {
+                Ok(coauthors) => {
+                    println!("setting {:#?}", coauthors);
+                },
+
+                Err(non_existing_usernames) => {
+                    println!(
+                        "{} could not be found in the storage. run `coauthor list` to see which one are available",
+                        non_existing_usernames.join(", ")
+                    );
+                }
+            }
         }
 
         InputCommand::Help => print_help_section(),


### PR DESCRIPTION
Using this will write to the git commit template file

Changes:
- Add `Set` to `InputCommand`
- Add `git_commit_template_file` module
- Add logic around finding coauthors through coauthors file