### PR TITLE
Create config directory when it is missing

### DIFF
--- a/src/coauthors_file.rs
+++ b/src/coauthors_file.rs
@@ -10,6 +10,9 @@ struct CoauthorsStorage {
 }
 
 fn coauthors_file() -> String {
+    let dir_path = tilde("~/.config/coauthor/").to_string();
+    fs::create_dir_all(&dir_path).unwrap();
+
     let file_path_string = tilde("~/.config/coauthor/coauthors.toml").to_string();
     let file_path = Path::new(&file_path_string);
 

--- a/src/coauthors_file.rs
+++ b/src/coauthors_file.rs
@@ -11,6 +11,7 @@ struct CoauthorsStorage {
 
 fn coauthors_file() -> String {
     let dir_path = tilde("~/.config/coauthor/").to_string();
+
     fs::create_dir_all(&dir_path).unwrap();
 
     let file_path_string = tilde("~/.config/coauthor/coauthors.toml").to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn run_command(command: InputCommand) {
                 println!(
                         "{} could not be found in the storage. run `coauthor list` to see which one are available",
                         non_existing_usernames.join(", ")
-                    );
+                        );
             }
         },
 
@@ -61,11 +61,11 @@ fn run_command(command: InputCommand) {
                     }
                 }
             }
-        },
+        }
 
         InputCommand::Clear => {
             git_commit_template_file::set_current_coauthors(vec![]);
-        },
+        }
 
         InputCommand::Help => print_help_section(),
 


### PR DESCRIPTION
This makes sure that we we're always able to create the
coauthors file in case there is none.