### PR TITLE
Fix problems around commit template file

### DIFF
--- a/src/git_commit_template_file.rs
+++ b/src/git_commit_template_file.rs
@@ -51,7 +51,7 @@ fn template_file() -> String {
     let mut path = String::from_utf8_lossy(&output.stdout).to_string();
     path.pop(); // Removes trailing `\n`
 
-    if path == "" || !Path::new(&path).exists()  {
+    if path == "" || !Path::new(&path).exists() {
         let dir_path = tilde("~/.config/git/").to_string();
         fs::create_dir_all(&dir_path).unwrap();
 

--- a/src/git_commit_template_file.rs
+++ b/src/git_commit_template_file.rs
@@ -59,7 +59,7 @@ fn template_file() -> String {
         let file_path = Path::new(&file_path_string);
         let _ = fs::File::create(file_path);
         let _ = Command::new("git")
-            .args(&["config", "set", "commit.template", &file_path_string])
+            .args(&["config", "commit.template", &file_path_string])
             .output()
             .expect("Failed to configure the git template file");
         println!("commit template missing. Added it to {}", file_path_string);

--- a/src/git_commit_template_file.rs
+++ b/src/git_commit_template_file.rs
@@ -51,7 +51,7 @@ fn template_file() -> String {
     let mut path = String::from_utf8_lossy(&output.stdout).to_string();
     path.pop(); // Removes trailing `\n`
 
-    if path == "" {
+    if path == "" || !Path::new(&path).exists()  {
         let file_path_string = tilde("~/.config/git/.gitmessage").to_string();
         let file_path = Path::new(&file_path_string);
         let _ = fs::File::create(file_path);

--- a/src/git_commit_template_file.rs
+++ b/src/git_commit_template_file.rs
@@ -52,6 +52,9 @@ fn template_file() -> String {
     path.pop(); // Removes trailing `\n`
 
     if path == "" || !Path::new(&path).exists()  {
+        let dir_path = tilde("~/.config/git/").to_string();
+        fs::create_dir_all(&dir_path).unwrap();
+
         let file_path_string = tilde("~/.config/git/.gitmessage").to_string();
         let file_path = Path::new(&file_path_string);
         let _ = fs::File::create(file_path);


### PR DESCRIPTION
Changes:
- Remove `set` from command setting commit template
- Ensure that `.config/git` folder exists
- Fix `coauthor current` crashes on missing file

Co-Authored-By: Louice Danielsson <21656089+louiced@users.noreply.github.com>